### PR TITLE
fix(handlers): define ensureInitialized() on Collections/Users/Actions to unblock 18 tools

### DIFF
--- a/src/mcp/handlers/actions.js
+++ b/src/mcp/handlers/actions.js
@@ -5,6 +5,12 @@ export class ActionsHandler {
     constructor(metabaseClient) {
         this.metabaseClient = metabaseClient;
     }
+  // Handler-level init is a no-op; MetabaseMCPServer.ensureInitialized()
+  // runs in CallToolRequestSchema before dispatch (see src/mcp/server.js).
+  // Kept as an instance hook so callers like this.ensureInitialized() do not
+  // throw TypeError when invoked from individual handler methods.
+  async ensureInitialized() {}
+
 
     routes() {
         return {

--- a/src/mcp/handlers/collections.js
+++ b/src/mcp/handlers/collections.js
@@ -5,6 +5,12 @@ export class CollectionsHandler {
   constructor(metabaseClient) {
     this.metabaseClient = metabaseClient;
   }
+  // Handler-level init is a no-op; MetabaseMCPServer.ensureInitialized()
+  // runs in CallToolRequestSchema before dispatch (see src/mcp/server.js).
+  // Kept as an instance hook so callers like this.ensureInitialized() do not
+  // throw TypeError when invoked from individual handler methods.
+  async ensureInitialized() {}
+
 
   routes() {
     return {

--- a/src/mcp/handlers/users.js
+++ b/src/mcp/handlers/users.js
@@ -5,6 +5,12 @@ export class UsersHandler {
   constructor(metabaseClient) {
     this.metabaseClient = metabaseClient;
   }
+  // Handler-level init is a no-op; MetabaseMCPServer.ensureInitialized()
+  // runs in CallToolRequestSchema before dispatch (see src/mcp/server.js).
+  // Kept as an instance hook so callers like this.ensureInitialized() do not
+  // throw TypeError when invoked from individual handler methods.
+  async ensureInitialized() {}
+
 
   routes() {
     return {


### PR DESCRIPTION
## Problem

`CollectionsHandler`, `UsersHandler` and `ActionsHandler` all call `await this.ensureInitialized()` inside their `handle*` methods, but **the method is only defined on `MetabaseMCPServer` (src/mcp/server.js), not on the handler classes**. Every tool routed through these three handlers throws at runtime:

```
TypeError: this.ensureInitialized is not a function
```

I reproduced this on v4.2.0 from npm against a live Metabase instance.

## Impact

A full bucket of MCP capabilities is currently unreachable — **18 tools** across collection management, user/permission management, and actions:

- `mb_collection_create`, `mb_collection_list`, `mb_collection_move`, `mb_collection_copy`, `mb_collection_permissions_get`, `mb_collection_permissions_update`
- `mb_user_list`, `mb_user_get`, `mb_user_create`, `mb_user_update`, `mb_user_disable`, `mb_permission_group_list`, `mb_permission_group_create`, `mb_permission_group_delete`, `mb_permission_group_add_user`, `mb_permission_group_remove_user`
- `mb_action_create`, `mb_action_execute`, `mb_action_list`

`CardsHandler`, `DashboardHandler`, `MetadataHandler`, etc. don't call `ensureInitialized()` so they're unaffected.

## Fix

`server.js` already calls its own `ensureInitialized()` in the `CallToolRequestSchema` handler **before** dispatching to any handler, so real init is guaranteed by the time these methods run. The minimal fix is to declare a no-op `async ensureInitialized()` on each handler class so the in-method calls remain semantically valid without duplicating server-level init logic.

```diff
 export class CollectionsHandler {
   constructor(metabaseClient) {
     this.metabaseClient = metabaseClient;
   }
+
+  // Handler-level init is a no-op; MetabaseMCPServer.ensureInitialized()
+  // runs in CallToolRequestSchema before dispatch (see src/mcp/server.js).
+  async ensureInitialized() {}
```

Same three lines added to `UsersHandler` and `ActionsHandler`.

## Alternatives considered

- **Remove all `await this.ensureInitialized()` calls** from the handlers — works too, but it's ~16 line deletions and risks reverting unrelated intent if the original author planned to add handler-specific init later.
- **Extract a `BaseHandler` class** the three handlers extend — cleaner but a larger surface change for what's effectively a missing-method stub.

The no-op stub is the smallest reversible change that restores functionality.

## Verification

```js
// before: TypeError
// after:
await client.callTool({ name: "mb_collection_list", arguments: {} });
// returns the collections list
```

I also confirmed against `tontv-dev-dashboard.motcaigido.xyz` that `GET /api/collection` and `GET /api/action` respond 200 with the patched build — the only barrier was the missing handler method.

## Notes

- Pure additive change, 3 files, +18/-0 LoC.
- No new dependencies, no tests touched (no test suite covers these tools yet).