### PR TITLE
fix(tool-registry): mb_card_data.parameters must be an array (closes #11)

### DIFF
--- a/src/mcp/tool-registry.js
+++ b/src/mcp/tool-registry.js
@@ -3006,8 +3006,9 @@ export function getToolDefinitions() {
             description: 'Output format'
           },
           parameters: {
-            type: 'object',
-            description: 'Optional parameters for parametric questions'
+            type: 'array',
+            items: { type: 'object' },
+            description: 'Optional parameters for parametric questions. Array of {type, target, value} objects per Metabase REST API spec.'
           }
         },
         required: ['card_id']


### PR DESCRIPTION
Closes #11.

## Problem

The MCP tool schema in `src/mcp/tool-registry.js` declares:

```js
parameters: {
  type: 'object',
  description: 'Optional parameters for parametric questions'
}
```

But the Metabase REST endpoint `POST /api/card/:id/query` expects `parameters` to be a **sequential array of `{type, target, value}` objects** ([Metabase API reference](https://www.metabase.com/docs/latest/api/card#post-apicardcard-idquery)), not a single object.

Result: MCP clients that validate input against the declared schema (Claude Code, Cursor) reject correctly-shaped arrays. `mb_card_data` cannot pass parameters to parametric questions at all — the only workaround is bypassing MCP and calling REST directly. This matches the report in #11.

## Fix

```diff
   parameters: {
-    type: 'object',
-    description: 'Optional parameters for parametric questions'
+    type: 'array',
+    items: { type: 'object' },
+    description: 'Optional parameters for parametric questions. Array of {type, target, value} objects per Metabase REST API spec.'
   }
```

The handler in `src/mcp/handlers/cards.js` already forwards `parameters` unchanged into the request body:

```js
const result = await this.metabaseClient.request('POST', endpoint, { parameters });
```

So an array reaches the API as-is. No handler change required.

## Caller example after fix

Non-parametric card:
```js
await client.callTool({ name: "mb_card_data", arguments: { card_id: 49, parameters: [] } });
```

Parametric card:
```js
await client.callTool({
  name: "mb_card_data",
  arguments: {
    card_id: 81,
    parameters: [
      { type: "category",
        target: ["variable", ["template-tag", "region"]],
        value: "APAC" }
    ]
  }
});
```

## Notes

- Single-file change, +3/-2 LoC, no behavioural change for handlers.
- Reproduced on v4.2.0 against a hosted Metabase instance.